### PR TITLE
Bumped up to version 1.0.0 minimum of monad-control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.cabal-sandbox
+cabal.sandbox.config
+dist
+*.sublime-*

--- a/timers.cabal
+++ b/timers.cabal
@@ -25,11 +25,11 @@ library
         Control.Concurrent.Timer.Types
 
     build-depends:
-        base              >= 4.5 && < 5
-      , lifted-base       >= 0.1 && < 0.3
-      , monad-control     >= 0.3 && < 0.4
-      , suspend           >= 0.2 && < 0.3
-      , transformers-base >= 0.4 && < 0.5
+        base              >= 4.5    && < 5
+      , lifted-base       >= 0.1    && < 0.3
+      , monad-control     >= 1.0.0  && < 2
+      , suspend           >= 0.2    && < 0.3
+      , transformers-base >= 0.4    && < 0.5
 
     hs-source-dirs:      src
     ghc-options:         -Wall -fwarn-unused-imports


### PR DESCRIPTION
The previous upper bound on monad-control conflicted with a bunch of other stuff so I pulled it up to 1.0.0 minimum. I'm not aware of if the minimum bound can be set lower however.